### PR TITLE
fix: caddy cve by using wolfi variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   id-token: write
   packages: write
+  pull-requests: write
 
 jobs:
   generate-matrix:
@@ -137,7 +138,7 @@ jobs:
 
       - if: github.ref == 'refs/heads/main'
         run: ./regctl-linux-amd64 image copy ${{ matrix.fpm-patch-image }} ${{ matrix.fpm-patch-hub-image }}
-  
+
   caddy:
     name: Build Caddy ${{ matrix.php }}
     runs-on: ubuntu-latest
@@ -170,6 +171,18 @@ jobs:
             SUPERVISORD_DIGEST=${{ matrix.supervisordDigest }}
           push: true
           provenance: false
+
+      - name: Docker Scout
+        id: docker-scout
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: docker/scout-action@v1
+        with:
+          command: compare
+          to: ${{ matrix.scan-to }}
+          image: ${{ matrix.scan-tag }}
+          organization: shopware
+          ignore-unchanged: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check:
     name: Test Image

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -6,8 +6,9 @@ FROM ghcr.io/shopware/docker-base:${PHP_PATCH_VERSION}-fpm
 
 USER root
 
-RUN apk add --no-cache caddy && \
-    ln -s /usr/sbin/caddy /usr/bin/caddy
+RUN wget -O /etc/apk/keys/wolfi-signing.rsa.pub https://packages.wolfi.dev/os/wolfi-signing.rsa.pub && \
+    apk add --no-cache --repository https://packages.wolfi.dev/os caddy && \
+    ln -s /usr/bin/caddy /usr/sbin/caddy
 
 COPY --from=shyim/supervisord:latest --link /usr/local/bin/supervisord /usr/bin/supervisord
 

--- a/matrix.php
+++ b/matrix.php
@@ -90,6 +90,8 @@ foreach ($supportedVersions as $supportedVersion)
         'fpm-hub-image' => 'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-fpm',
         'fpm-patch-hub-image' => 'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-fpm',
         'caddy-tags' => implode("\n", $caddyImages),
+        'scan-tag' => $caddyImages[0],
+        'scan-to' => 'ghcr.io/shopware/docker-base:'.$supportedVersion,
     ];
 }
 


### PR DESCRIPTION
Fixes all caddy cve
<img width="1611" alt="image" src="https://github.com/shopware/docker/assets/6224096/9c6c918e-a8c8-42d3-abdc-2748b1a78c5b">
