### PR TITLE
Fixed typo in PHP session.cookie_lifetime configuration variable name

### DIFF
--- a/fpm/rootfs/usr/local/etc/php/conf.d/docker.ini
+++ b/fpm/rootfs/usr/local/etc/php/conf.d/docker.ini
@@ -8,7 +8,7 @@ post_max_size = ${PHP_MAX_UPLOAD_SIZE}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 memory_limit = ${PHP_MEMORY_LIMIT}
 
-session.cookie_lifetime = ${PHP_SESSION_COOKIE_MAXLIFETIME}
+session.cookie_lifetime = ${PHP_SESSION_COOKIE_LIFETIME}
 session.save_handler = ${PHP_SESSION_HANDLER}
 session.save_path = ${PHP_SESSION_SAVE_PATH}
 session.gc_probability = 0


### PR DESCRIPTION
I made a typo in #79 so the variable in the config file did not match the variable used for the default value and the documentation in the readme.

~~PHP_SESSION_COOKIE_MAXLIFETIME~~ -> PHP_SESSION_COOKIE_LIFETIME