### PR TITLE
add post setup hook

### DIFF
--- a/fpm/rootfs/usr/local/shopware/setup_6.5.x
+++ b/fpm/rootfs/usr/local/shopware/setup_6.5.x
@@ -31,3 +31,5 @@ else
 
   run_hooks post_install
 fi
+
+run_hooks post_setup

--- a/fpm/rootfs/usr/local/shopware/setup_6.6.x
+++ b/fpm/rootfs/usr/local/shopware/setup_6.6.x
@@ -40,3 +40,5 @@ else
 
   run_hooks post_install
 fi
+
+run_hooks post_setup


### PR DESCRIPTION
This would be useful for running tasks after the setup has completed, such as installing dependencies with Composer. This hook will executed regardless of whether the system is already installed or not