### PR TITLE
docs: add low_priority queue worker to example compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ services:
             init:
                 condition: service_completed_successfully
         env_file: .app.env
-        entrypoint: [ "php", "bin/console", "messenger:consume", "async", "--time-limit=300", "--memory-limit=512M" ]
+        entrypoint: [ "php", "bin/console", "messenger:consume", "async", "low_priority", "--time-limit=300", "--memory-limit=512M" ]
         deploy:
             replicas: 3
 


### PR DESCRIPTION
The current example would've skipped messages on the `low_priority` queue,
which was introduced in Shopware 6.5.7.0.

My guess is, that it was intentionally left out to not break on some
older instances. As noted in the documentation:

> The transports option can only be configured with the low_priority transport
> if you are on version 6.5.7.0 or above.

https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#admin-worker

It should be safe to change as that is a relatively old version (a full major
behind) and if you copy the example you probably use a current version.
