### PR TITLE
Added git

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -7,7 +7,7 @@ FROM docker.io/library/php:${PHP_PATCH_VERSION}-fpm-alpine@${PHP_DIGEST}
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN apk add --no-cache icu-data-full curl jq trurl && \
+RUN apk add --no-cache icu-data-full curl jq trurl git && \
     apk upgrade --no-cache && \
     chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \


### PR DESCRIPTION
As mentioned in #94 shopware V6.6.4.0 needs git now.
I added git in the Dockerfile for the Base Image so there is no need to install git in every shopware container build.