### PR TITLE
feat: eanble zstd

### DIFF
--- a/caddy/rootfs/etc/caddy/Caddyfile
+++ b/caddy/rootfs/etc/caddy/Caddyfile
@@ -12,7 +12,7 @@ route {
 	php_fastcgi @default unix//tmp/php-fpm.sock {
 		trusted_proxies private_ranges
 	}
-	encode gzip
+	encode gzip zstd
 	file_server
 
 	{$CADDY_SERVER_EXTRA_DIRECTIVES}


### PR DESCRIPTION
zstd is faster to compress and saves time on edge (Cloudflare, Fastly), so they don't have to upgrade from gzip to zstd