### PR TITLE
Add sitemap handling to Nginx and update Caddy config

### DIFF
--- a/caddy/rootfs/etc/caddy/Caddyfile
+++ b/caddy/rootfs/etc/caddy/Caddyfile
@@ -6,7 +6,7 @@ log
 
 route {
 	@default {
-		not path /theme/* /media/* /thumbnail/* /bundles/* /sitemap/*
+		not path /theme/* /media/* /thumbnail/* /bundles/*
 	}
 	root * /var/www/html/public
 	php_fastcgi @default unix//tmp/php-fpm.sock {

--- a/nginx/rootfs/etc/nginx/nginx.conf
+++ b/nginx/rootfs/etc/nginx/nginx.conf
@@ -53,6 +53,11 @@ http {
             deny all;
         }
 
+        # Allow sitemap requests to hit the shopware application
+        location ~ ^/sitemap/.*\.(xml|xml\.gz)$ {
+            try_files $uri /index.php$is_args$args;
+        }
+
         location ~ ^/(theme|media|thumbnail|bundles|css|fonts|js|recovery|sitemap)/ {
             expires 1y;
             add_header Cache-Control "public, must-revalidate, proxy-revalidate";


### PR DESCRIPTION
Added a new Nginx location block to allow sitemap requests to reach the Shopware application. Updated the Caddy configuration to exclude sitemap paths from the @default route matching. These changes ensure proper handling of sitemap requests in both servers.