### PR TITLE
feat(nginx): load additional config from `/etc/nginx/conf.d`

### DIFF
--- a/nginx/rootfs/etc/nginx/nginx.conf
+++ b/nginx/rootfs/etc/nginx/nginx.conf
@@ -140,5 +140,9 @@ http {
         gzip_min_length 1000;
         gzip_proxied expired no-cache no-store private auth;
         gzip_types text/plain text/css application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript application/atom+xml application/json application/vnd.api+json application/rss+xml application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype application/x-font-ttf application/xhtml+xml font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon;
+
+        include /etc/nginx/conf.d/*.inc;
     }
+
+    include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
This MR adds the ability to auto load additional config fount under `/etc/nginx/conf.d`

All `.conf` are loaded to the `http` section and `.inc` to the default `server` section

Useful for adding rewrite rules to the `server` section or additional `server` sections