### PR TITLE
fix(docker): add missing 'ftp' extension to PHP installation in Docke…

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -11,7 +11,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache icu-data-full curl jq trurl && \
     apk upgrade --no-cache && \
     chmod +x /usr/local/bin/install-php-extensions && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ffi opcache ${REDIS_PHP_MODULE} apcu-5.1.24 amqp-2.1.2 zstd-0.13.3  && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ftp ffi opcache ${REDIS_PHP_MODULE} apcu-5.1.24 amqp-2.1.2 zstd-0.13.3  && \
     mkdir -p /var/www/html && \
     mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" && \
     rm -f /usr/local/etc/php-fpm.d/zz-docker.conf && \

--- a/frankenphp/Dockerfile
+++ b/frankenphp/Dockerfile
@@ -25,7 +25,7 @@ RUN <<EOF
     set -e
     apt-get update
     apt-get upgrade -y
-    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ffi opcache redis apcu amqp zstd
+    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ftp ffi opcache redis apcu amqp zstd
     mkdir -p /var/www/html
     usermod -u 82 www-data
     groupmod -g 82 www-data


### PR DESCRIPTION
Adds ftp extension by default, some dependencies of plugins required it. 
ftp is an official php extension and just 60kb