### PR TITLE
feat: add node image variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
             PHP_VERSION=${{ matrix.php }}
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
+            NODE_VERSION=${{ matrix.node }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
             NODE_VERSION=${{ matrix.node }}
           push: true
@@ -112,6 +113,7 @@ jobs:
             PHP_VERSION=${{ matrix.php }}
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
+            NODE_VERSION=${{ matrix.node }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
             NODE_VERSION=${{ matrix.node }}
           push: true
@@ -204,6 +206,7 @@ jobs:
           build-args: |
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
+            NODE_VERSION=${{ matrix.node }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
             NODE_VERSION=${{ matrix.node }}
           push: true
@@ -240,6 +243,7 @@ jobs:
           build-args: |
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
+            NODE_VERSION=${{ matrix.node }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
             NODE_VERSION=${{ matrix.node }}
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Login into Github Docker Registery
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-    
+
       - name: Build and Push
         if: matrix.php != '8.1'
         uses: docker/build-push-action@v6
@@ -279,7 +279,7 @@ jobs:
 
       - name: Login into Github Docker Registery
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-    
+
       - name: Build and Push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
+            NODE_VERSION=${{ matrix.node }}
           push: true
           provenance: false
 
@@ -112,6 +113,7 @@ jobs:
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
+            NODE_VERSION=${{ matrix.node }}
           push: true
           provenance: false
 
@@ -203,6 +205,7 @@ jobs:
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
+            NODE_VERSION=${{ matrix.node }}
           push: true
           provenance: false
 
@@ -238,6 +241,7 @@ jobs:
             PHP_PATCH_VERSION=${{ matrix.phpPatch }}
             PHP_DIGEST=${{ matrix.phpPatchDigest }}
             REDIS_PHP_MODULE=${{ matrix.redisPHPModule }}
+            NODE_VERSION=${{ matrix.node }}
           push: true
           provenance: false
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -20,6 +20,28 @@ RUN apk add --no-cache icu-data-full curl jq trurl && \
     rm -f /usr/local/etc/php-fpm.d/www.conf && \
     rm -f /usr/local/etc/php-fpm.d/www.conf.default
 
+COPY --link rootfs /
+
+ARG NODE_VERSION
+FROM fpm AS fpm-node
+
+ENV NODE_VERSION=${NODE_VERSION}
+
+RUN <<EOF
+compile-node
+EOF
+
+FROM fpm-node as local-node-22
+
+FROM fpm-node as local-node-24
+
+FROM fpm as local-node-none
+
+ARG NODE_VERSION
+FROM local-node-${NODE_VERSION:-none} AS all-deps
+
+FROM all-deps AS runtime-config
+
 ENV APP_ENV=prod \
     APP_URL_CHECK_DISABLED=1 \
     LOCK_DSN=flock \
@@ -72,30 +94,8 @@ ENV APP_ENV=prod \
 
 USER www-data
 
-COPY --link rootfs /
-
 WORKDIR /var/www/html
 
-ARG NODE_VERSION
-FROM fpm AS fpm-node
-
-ENV NODE_VERSION=${NODE_VERSION}
-
-USER root
-
-RUN <<EOF
-compile-node
-EOF
-
-USER www-data
-
-FROM fpm-node as local-node-22
-
-FROM fpm-node as local-node-24
-
-FROM fpm as local-node-none
-
-ARG NODE_VERSION
-FROM local-node-${NODE_VERSION:-none} AS final
+FROM runtime-config AS final
 
 FROM final

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -77,40 +77,25 @@ COPY --link rootfs /
 WORKDIR /var/www/html
 
 ARG NODE_VERSION
-FROM docker.io/library/node${NODE_VERSION:+:}${NODE_VERSION:+$NODE_VERSION-alpine} AS node
-
 FROM fpm AS fpm-node
 
-COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --link --from=node /opt/yarn-* /opt/
-
-COPY --link --from=node \
-    /usr/local/bin/node \
-    /usr/local/bin/
-
-COPY --link --from=node  \
-    /usr/local/include/node \
-    /usr/local/include/
+ENV NODE_VERSION=${NODE_VERSION}
 
 USER root
 
 RUN <<EOF
-ln -s /usr/local/bin/node /usr/local/bin/nodejs
-ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
-ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-ln -s /opt/yarn-*/bin/yarn /usr/local/bin/yarn
-ln -s /opt/yarn-*/bin/yarnpkg /usr/local/bin/yarnpkg
+compile-node
 EOF
 
 USER www-data
 
-FROM fpm-node as node-22
+FROM fpm-node as local-node-22
 
-FROM fpm-node as node-24
+FROM fpm-node as local-node-24
 
-FROM fpm as node-none
+FROM fpm as local-node-none
 
 ARG NODE_VERSION
-FROM node-${NODE_VERSION:-none} AS final
+FROM local-node-${NODE_VERSION:-none} AS final
 
 FROM final

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -3,7 +3,9 @@
 ARG PHP_PATCH_VERSION
 ARG PHP_DIGEST
 
-FROM docker.io/library/php:${PHP_PATCH_VERSION}-fpm-alpine@${PHP_DIGEST}
+ARG NODE_VERSION=none
+
+FROM docker.io/library/php:${PHP_PATCH_VERSION}-fpm-alpine@${PHP_DIGEST} AS fpm
 ARG REDIS_PHP_MODULE=redis
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
@@ -73,3 +75,42 @@ USER www-data
 COPY --link rootfs /
 
 WORKDIR /var/www/html
+
+ARG NODE_VERSION
+FROM docker.io/library/node${NODE_VERSION:+:}${NODE_VERSION:+$NODE_VERSION-alpine} AS node
+
+FROM fpm AS fpm-node
+
+COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules/
+COPY --link --from=node /opt/yarn-* /opt/
+
+COPY --link --from=node \
+    /usr/local/bin/node \
+    /usr/local/bin/
+
+COPY --link --from=node  \
+    /usr/local/include/node \
+    /usr/local/include/
+
+USER root
+
+RUN <<EOF
+ln -s /usr/local/bin/node /usr/local/bin/nodejs
+ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+ln -s /opt/yarn-*/bin/yarn /usr/local/bin/yarn
+ln -s /opt/yarn-*/bin/yarnpkg /usr/local/bin/yarnpkg
+EOF
+
+USER www-data
+
+FROM node as node-22
+
+FROM node as node-24
+
+FROM fpm as node-none
+
+ARG NODE_VERSION
+FROM node-${NODE_VERSION:-none} AS final
+
+FROM final

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -81,7 +81,7 @@ FROM docker.io/library/node${NODE_VERSION:+:}${NODE_VERSION:+$NODE_VERSION-alpin
 
 FROM fpm AS fpm-node
 
-COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules/
+COPY --link --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --link --from=node /opt/yarn-* /opt/
 
 COPY --link --from=node \
@@ -104,9 +104,9 @@ EOF
 
 USER www-data
 
-FROM node as node-22
+FROM fpm-node as node-22
 
-FROM node as node-24
+FROM fpm-node as node-24
 
 FROM fpm as node-none
 

--- a/fpm/rootfs/usr/local/bin/compile-node
+++ b/fpm/rootfs/usr/local/bin/compile-node
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -e
+set -x
+
+echo "Building nodeJS from source"
+
+apk add --no-cache --virtual .build-deps-full \
+    binutils-gold \
+    g++ \
+    gcc \
+    gnupg \
+    libgcc \
+    linux-headers \
+    make \
+    python3 \
+    py-setuptools
+
+export GNUPGHOME="$(mktemp -d)"
+
+gpg --batch --keyserver "hkps://keys.openpgp.org" --recv-keys $(curl -fsSL 'https://raw.githubusercontent.com/nodejs/docker-node/refs/heads/main/keys/node.keys' | tr '\n' ' ')
+
+# Check length of NODE_VERSION; if it's less than 6 chars, we need to determine the major and fetch the latest version
+if [ ${#NODE_VERSION} -lt 6 ]; then
+  export NODE_VERSION=$(curl -fsSL "https://nodejs.org/dist/index.tab" | awk -v "MAJOR=$NODE_VERSION" '$1 ~ "^v"MAJOR { print substr($1, 2) }' | sort -rV | head -1)
+fi
+
+curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz"
+curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"
+
+gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+
+gpgconf --kill all
+rm -rf "$GNUPGHOME"
+
+grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c -
+
+tar -xf "node-v$NODE_VERSION.tar.xz"
+
+cd "node-v$NODE_VERSION"
+
+./configure
+make -j$(getconf _NPROCESSORS_ONLN) V=
+make install
+
+apk del .build-deps-full
+
+cd ..
+rm -Rf "node-v$NODE_VERSION"
+rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt;

--- a/fpm/rootfs/usr/local/bin/compile-node
+++ b/fpm/rootfs/usr/local/bin/compile-node
@@ -2,48 +2,113 @@
 set -e
 set -x
 
-echo "Building nodeJS from source"
+function determine_full_version() {
+  local major; major="${1}"
 
-apk add --no-cache --virtual .build-deps-full \
-    binutils-gold \
-    g++ \
-    gcc \
-    gnupg \
-    libgcc \
-    linux-headers \
-    make \
-    python3 \
-    py-setuptools
+  curl -fsSL https://nodejs.org/dist/index.tab | awk -v "MAJOR=${major}" '$1 ~ "^v"MAJOR { print substr($1, 2) }' | sort -V | tail -1
+}
 
-export GNUPGHOME="$(mktemp -d)"
+function install_build_deps() {
+  local alias; alias="${1:-.build-deps-full}"
 
-gpg --batch --keyserver "hkps://keys.openpgp.org" --recv-keys $(curl -fsSL 'https://raw.githubusercontent.com/nodejs/docker-node/refs/heads/main/keys/node.keys' | tr '\n' ' ')
+  apk add --no-cache --virtual "${alias}" \
+      binutils-gold \
+      g++ \
+      gcc \
+      gnupg \
+      libgcc \
+      linux-headers \
+      make \
+      python3 \
+      py-setuptools
+}
 
-# Check length of NODE_VERSION; if it's less than 6 chars, we need to determine the major and fetch the latest version
-if [ ${#NODE_VERSION} -lt 6 ]; then
-  export NODE_VERSION=$(curl -fsSL "https://nodejs.org/dist/index.tab" | awk -v "MAJOR=$NODE_VERSION" '$1 ~ "^v"MAJOR { print substr($1, 2) }' | sort -rV | head -1)
-fi
+function remove_build_deps() {
+  local alias; alias="${1:-.build-deps-full}"
 
-curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz"
-curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc"
+  apk del "${alias}"
+}
 
-gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
+function import_maintainer_keys() {
+  local gpg_home; gpg_home="${1}"
 
-gpgconf --kill all
-rm -rf "$GNUPGHOME"
+  gpg \
+    --homedir "${gpg_home}" \
+    --batch \
+    --keyserver "hkps://keys.openpgp.org" \
+    --recv-keys \
+    $(curl -fsSL 'https://raw.githubusercontent.com/nodejs/docker-node/refs/heads/main/keys/node.keys' | tr '\n' ' ')
+}
 
-grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c -
+function download_node_source() {
+  curl -fsSLO --compressed "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.tar.xz"
+}
 
-tar -xf "node-v$NODE_VERSION.tar.xz"
+function verify_checksums() {
+  local gpg_home; gpg_home="${1:-$(mktemp -d)}"
 
-cd "node-v$NODE_VERSION"
+  import_maintainer_keys "${gpg_home}"
 
-./configure
-make -j$(getconf _NPROCESSORS_ONLN) V=
-make install
+  curl -fsSLO --compressed "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt.asc"
 
-apk del .build-deps-full
+  gpg --homedir="${gpg_home}" --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc
 
-cd ..
-rm -Rf "node-v$NODE_VERSION"
-rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt;
+  gpgconf --kill all
+  rm -rf "${gpg_home}"
+
+  grep " node-v${NODE_VERSION}.tar.xz\$" SHASUMS256.txt | sha256sum -c -
+}
+
+build_node() {
+  tar -xf "node-v${NODE_VERSION}.tar.xz"
+
+  cd "node-v${NODE_VERSION}"
+
+  echo "Building nodeJS from source"
+
+  ./configure
+  make -j$(getconf _NPROCESSORS_ONLN) V=
+  make install
+
+  cd ..
+
+  rm -Rf "node-v${NODE_VERSION}"
+  rm "node-v${NODE_VERSION}.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt;
+}
+
+general_cleanup() {
+  find /usr/local/include/node/openssl/archs -mindepth 1 -maxdepth 1 ! -name "$OPENSSL_ARCH" -exec rm -rf {} \; || true
+  rm -rf /tmp/*
+}
+
+smoketest() {
+  node --version
+  npm --version
+}
+
+function main() {
+    if [ -z "${NODE_VERSION}" ]; then
+      echo "NODE_VERSION is not set!" >&2
+      exit 1
+    fi
+
+    if [ ${#NODE_VERSION} -lt 6 ]; then
+      export NODE_VERSION=$(determine_full_version "${NODE_VERSION}")
+    fi
+
+    install_build_deps || exit 1
+
+    download_node_source || exit 1
+
+    verify_checksums || exit 1
+
+    build_node || exit 1
+
+    remove_build_deps || exit 1
+
+    general_cleanup || true
+
+    smoketest || exit 1
+}
+
+main

--- a/matrix.php
+++ b/matrix.php
@@ -20,191 +20,204 @@ function get_digest_of_image(string $imageName, string $tag): string {
     return $digest;
 }
 
+function node_version_suffix(?string $nodeVersion): string {
+    if ($nodeVersion === null) {
+        return '';
+    }
+
+    return '-node-' . $nodeVersion;
+}
+
 $supportedVersions = ['8.1', '8.2', '8.3', '8.4'];
 $disallowedVersions = ['8.2.20', '8.3.8'];
 $rcVersions = [];
+
+$supportedNodeVersions = [null, '22', '24'];
 
 $data = [];
 
 $versionRegex ='/^(?<version>\d\.\d\.\d{1,}(RC\d)?)/m';
 
 
-foreach ($supportedVersions as $supportedVersion)
-{
+foreach ($supportedNodeVersions as $supportedNodeVersion) {
+    foreach ($supportedVersions as $supportedVersion)
+    {
 
-    $curVersion = null;
-    $patchVersion = null;
-    $rcVersion = null;
+        $curVersion = null;
+        $patchVersion = null;
+        $rcVersion = null;
 
-    $page = 0;
+        $page = 0;
 
-    do {
-        $apiResponse = json_decode(file_get_contents('https://hub.docker.com/v2/repositories/library/php/tags/?page_size=50&page=' . $page . '&name=' . $supportedVersion. '.'), true);
+        do {
+            $apiResponse = json_decode(file_get_contents('https://hub.docker.com/v2/repositories/library/php/tags/?page_size=50&page=' . $page . '&name=' . $supportedVersion. '.'), true);
 
-        if (!is_array($apiResponse)) {
-            throw new \RuntimeException("invalid api response");
-        }
-
-        foreach ($apiResponse['results'] as $entry) {
-            preg_match($versionRegex, $entry['name'], $rcVersion);
-
-            if (strpos($entry['name'], 'RC') !== false && !in_array($rcVersion['version'], $rcVersions)) {
-                continue;
+            if (!is_array($apiResponse)) {
+                throw new \RuntimeException("invalid api response");
             }
 
-            if (preg_match($versionRegex, $entry['name'], $patchVersion)) {
-                if (in_array($patchVersion['version'], $disallowedVersions, true)) {
-                    $patchVersion = null;
+            foreach ($apiResponse['results'] as $entry) {
+                preg_match($versionRegex, $entry['name'], $rcVersion);
+
+                if (strpos($entry['name'], 'RC') !== false && !in_array($rcVersion['version'], $rcVersions)) {
                     continue;
                 }
 
+                if (preg_match($versionRegex, $entry['name'], $patchVersion)) {
+                    if (in_array($patchVersion['version'], $disallowedVersions, true)) {
+                        $patchVersion = null;
+                        continue;
+                    }
+
+                    break;
+                }
+            }
+
+            if ($patchVersion !== null) {
                 break;
             }
+
+        } while($page++ < 5);
+
+        if ($patchVersion === null) {
+            throw new \RuntimeException('There is no version found for PHP ' . $supportedVersion);
         }
 
-        if ($patchVersion !== null) {
-            break;
+        $phpDigest = get_digest_of_image('library/php', $patchVersion['version'] . '-fpm-alpine');
+
+        $imageTagPrefix = $_SERVER['GITHUB_REF'] !== 'refs/heads/main' ? ($_SERVER['GITHUB_RUN_ID'] . '-') : '';
+
+        $imageSuffix = $_SERVER['GITHUB_REF'] !== 'refs/heads/main' ? '-ci-test' : '';
+
+        $caddyImages = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion),
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-caddy',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion),
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-caddy',
+        ];
+
+        $caddyImagesOtel = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-caddy-otel',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-caddy-otel',
+        ];
+
+        $nginxImages = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-nginx',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-nginx',
+        ];
+
+        $nginxImagesOtel = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-nginx-otel',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-nginx-otel',
+        ];
+
+        $frankenphpImages = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-frankenphp',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-frankenphp'
+        ];
+
+        $frankenphpImagesOtel = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-frankenphp-otel',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-frankenphp-otel'
+        ];
+
+        $fpmImages = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-fpm',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-fpm'
+        ];
+
+        $fpmImagesOtel = [
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-fpm-otel',
+            'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-fpm-otel'
+        ];
+
+        if ($_SERVER['GITHUB_REF'] === 'refs/heads/main') {
+            $caddyImages = array_merge($caddyImages, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion),
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-caddy',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion),
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-caddy',
+            ]);
+
+            $caddyImagesOtel = array_merge($caddyImagesOtel, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-caddy-otel',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-caddy-otel',
+            ]);
+
+            $nginxImages = array_merge($nginxImages, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-nginx',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-nginx',
+            ]);
+
+            $nginxImagesOtel = array_merge($nginxImagesOtel, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-nginx-otel',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-nginx-otel',
+            ]);
+
+            $fpmImages = array_merge($fpmImages, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-fpm',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-fpm'
+            ]);
+
+            $fpmImagesOtel = array_merge($fpmImagesOtel, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-fpm-otel',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-fpm-otel'
+            ]);
+
+            $frankenphpImages = array_merge($frankenphpImages, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-frankenphp',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-frankenphp'
+            ]);
+
+            $frankenphpImagesOtel = array_merge($frankenphpImagesOtel, [
+                'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-frankenphp-otel',
+                'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . node_version_suffix($supportedNodeVersion) . '-frankenphp-otel'
+            ]);
         }
 
-    } while($page++ < 5);
+        $redisModule = 'redis';
+        if (version_compare($patchVersion['version'], '8.4', '<')) {
+            $redisModule = 'redis-6.0.2';
+        }
 
-    if ($patchVersion === null) {
-        throw new \RuntimeException('There is no version found for PHP ' . $supportedVersion);
+        $manifestMergeScript = '';
+
+        foreach($fpmImages as $fpmImage) {
+            $manifestMergeScript .= 'docker manifest create ' . $fpmImage . ' ' . $fpmImage . '-amd64 ' . $fpmImage . '-arm64' . "\n";
+            $manifestMergeScript .= 'docker manifest push ' . $fpmImage . "\n";
+        }
+
+        $manifestMergeScriptFrankenphp = '';
+        foreach($frankenphpImages as $frankenphpImage) {
+            $manifestMergeScriptFrankenphp .= 'docker manifest create ' . $frankenphpImage . ' ' . $frankenphpImage . '-amd64 ' . $frankenphpImage . '-arm64' . "\n";
+            $manifestMergeScriptFrankenphp .= 'docker manifest push ' . $frankenphpImage . "\n";
+        }
+
+        $data[] = [
+            'php' => $supportedVersion,
+            'phpPatch' => $patchVersion['version'],
+            'phpPatchDigest' => $phpDigest,
+            'node' => $supportedNodeVersion ?? '',
+            'frankenphp-image' => 'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-frankenphp',
+            'frankenphp-merge' => $manifestMergeScriptFrankenphp,
+            'frankenphp-tags-amd64' => implode("\n", array_map(fn($tag) => $tag . '-amd64', $frankenphpImages)),
+            'frankenphp-tags-arm64' => implode("\n", array_map(fn($tag) => $tag . '-arm64', $frankenphpImages)),
+            'frankenphp-tags-otel' => implode("\n", $frankenphpImagesOtel),
+            'fpm-image' => 'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . node_version_suffix($supportedNodeVersion) . '-fpm',
+            'fpm-tags' => implode("\n", $fpmImages),
+            'fpm-merge' => $manifestMergeScript,
+            'fpm-tags-amd64' => implode("\n", array_map(fn($tag) => $tag . '-amd64', $fpmImages)),
+            'fpm-tags-arm64' => implode("\n", array_map(fn($tag) => $tag . '-arm64', $fpmImages)),
+            'fpm-tags-otel' => implode("\n", $fpmImagesOtel),
+            'caddy-tags' => implode("\n", $caddyImages),
+            'caddy-tags-otel' => implode("\n", $caddyImagesOtel),
+            'nginx-tags' => implode("\n", $nginxImages),
+            'nginx-tags-otel' => implode("\n", $nginxImagesOtel),
+            'scan-tag' => $caddyImages[0],
+            'scan-to' => 'ghcr.io/shopware/docker-base:' . $supportedVersion . node_version_suffix($supportedNodeVersion),
+            'redisPHPModule' => $redisModule,
+        ];
     }
-
-    $phpDigest = get_digest_of_image('library/php', $patchVersion['version'] . '-fpm-alpine');
-
-    $imageTagPrefix = $_SERVER['GITHUB_REF'] !== 'refs/heads/main' ? ($_SERVER['GITHUB_RUN_ID'] . '-') : '';
-
-    $imageSuffix = $_SERVER['GITHUB_REF'] !== 'refs/heads/main' ? '-ci-test' : '';
-
-    $caddyImages = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion,
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-caddy',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'],
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . '-caddy',
-    ];
-
-    $caddyImagesOtel = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-caddy-otel',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . '-caddy-otel',
-    ];
-
-    $nginxImages = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-nginx',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . '-nginx',
-    ];
-    
-    $nginxImagesOtel = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-nginx-otel',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $patchVersion['version'] . '-nginx-otel',
-    ];
-
-    $frankenphpImages = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-frankenphp',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . '-frankenphp'
-    ];
-
-    $frankenphpImagesOtel = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-frankenphp-otel',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . '-frankenphp-otel'
-    ];
-
-    $fpmImages = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-fpm',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . '-fpm'
-    ];
-
-    $fpmImagesOtel = [
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-fpm-otel',
-        'ghcr.io/shopware/docker-base' . $imageSuffix . ':'  . $imageTagPrefix . $patchVersion['version'] . '-fpm-otel'
-    ];
-
-    if ($_SERVER['GITHUB_REF'] === 'refs/heads/main') {
-        $caddyImages = array_merge($caddyImages, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion,
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-caddy',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'],
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-caddy',
-        ]);
-
-        $caddyImagesOtel = array_merge($caddyImagesOtel, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-caddy-otel',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-caddy-otel',
-        ]);
-
-        $nginxImages = array_merge($nginxImages, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-nginx',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-nginx',
-        ]);
-
-        $nginxImagesOtel = array_merge($nginxImagesOtel, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-nginx-otel',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-nginx-otel',
-        ]);
-
-        $fpmImages = array_merge($fpmImages, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-fpm',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-fpm'
-        ]);
-
-        $fpmImagesOtel = array_merge($fpmImagesOtel, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-fpm-otel',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-fpm-otel'
-        ]);
-
-        $frankenphpImages = array_merge($frankenphpImages, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-frankenphp',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-frankenphp'
-        ]);
-
-        $frankenphpImagesOtel = array_merge($frankenphpImagesOtel, [
-            'shopware/docker-base:' . $imageTagPrefix . $supportedVersion . '-frankenphp-otel',
-            'shopware/docker-base:' . $imageTagPrefix . $patchVersion['version'] . '-frankenphp-otel'
-        ]);
-    }
-
-    $redisModule = 'redis';
-    if (version_compare($patchVersion['version'], '8.4', '<')) {
-        $redisModule = 'redis-6.0.2';
-    }
-
-    $manifestMergeScript = '';
-
-    foreach($fpmImages as $fpmImage) {
-        $manifestMergeScript .= 'docker manifest create ' . $fpmImage . ' ' . $fpmImage . '-amd64 ' . $fpmImage . '-arm64' . "\n";
-        $manifestMergeScript .= 'docker manifest push ' . $fpmImage . "\n";
-    }
-
-    $manifestMergeScriptFrankenphp = '';
-    foreach($frankenphpImages as $frankenphpImage) {
-        $manifestMergeScriptFrankenphp .= 'docker manifest create ' . $frankenphpImage . ' ' . $frankenphpImage . '-amd64 ' . $frankenphpImage . '-arm64' . "\n";
-        $manifestMergeScriptFrankenphp .= 'docker manifest push ' . $frankenphpImage . "\n";
-    }
-
-    $data[] = [
-        'php' => $supportedVersion,
-        'phpPatch' => $patchVersion['version'],
-        'phpPatchDigest' => $phpDigest,
-        'frankenphp-image' => 'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-frankenphp',
-        'frankenphp-merge' => $manifestMergeScriptFrankenphp,
-        'frankenphp-tags-amd64' => implode("\n", array_map(fn($tag) => $tag . '-amd64', $frankenphpImages)),
-        'frankenphp-tags-arm64' => implode("\n", array_map(fn($tag) => $tag . '-arm64', $frankenphpImages)),
-        'frankenphp-tags-otel' => implode("\n", $frankenphpImagesOtel),
-        'fpm-image' => 'ghcr.io/shopware/docker-base' . $imageSuffix . ':' . $imageTagPrefix . $supportedVersion . '-fpm',
-        'fpm-tags' => implode("\n", $fpmImages),
-        'fpm-merge' => $manifestMergeScript,
-        'fpm-tags-amd64' => implode("\n", array_map(fn($tag) => $tag . '-amd64', $fpmImages)),
-        'fpm-tags-arm64' => implode("\n", array_map(fn($tag) => $tag . '-arm64', $fpmImages)),
-        'fpm-tags-otel' => implode("\n", $fpmImagesOtel),
-        'caddy-tags' => implode("\n", $caddyImages),
-        'caddy-tags-otel' => implode("\n", $caddyImagesOtel),
-        'nginx-tags' => implode("\n", $nginxImages),
-        'nginx-tags-otel' => implode("\n", $nginxImagesOtel),
-        'scan-tag' => $caddyImages[0],
-        'scan-to' => 'ghcr.io/shopware/docker-base:'.$supportedVersion,
-        'redisPHPModule' => $redisModule,
-    ];
 }
 
 echo json_encode(['matrix' => ['include' => $data]], JSON_THROW_ON_ERROR);

--- a/matrix.php
+++ b/matrix.php
@@ -32,17 +32,30 @@ $supportedVersions = ['8.1', '8.2', '8.3', '8.4'];
 $disallowedVersions = ['8.2.20', '8.3.8'];
 $rcVersions = [];
 
-$supportedNodeVersions = [null, '22', '24'];
+$supportedNodeVersions = [
+    '8.1' => [
+        null,
+    ],
+    '8.2' => [
+        null,
+    ],
+    '8.3' => [
+        null,
+        '22',
+    ],
+    '8.4' => [
+        null,
+        '22',
+        '24',
+    ],
+];
 
 $data = [];
 
 $versionRegex ='/^(?<version>\d\.\d\.\d{1,}(RC\d)?)/m';
 
-
-foreach ($supportedNodeVersions as $supportedNodeVersion) {
-    foreach ($supportedVersions as $supportedVersion)
-    {
-
+foreach ($supportedVersions as $supportedVersion) {
+    foreach ($supportedNodeVersions[$supportedVersion] as $supportedNodeVersion) {
         $curVersion = null;
         $patchVersion = null;
         $rcVersion = null;


### PR DESCRIPTION
Resolves: #138

---

With this PR, we get another image variant that includes `node` as well.

Since the use of `COPY` is a bit unusual, I'll try to explain the direction I took here in more detail.

We need to support:
* arbitrary node versions, currently `v22` and `v24` (to support various shopware versions)
* multiple alpine base image versions (due to varying php versions)
* `musl` (due to alpine base image)
* `arm64` processor arch

So just calling `apk add nodejs` is not an option, as the node versions available to us would be dependant on the alpine repositories referenced in the `php:x-fpm-alpine` variant we build upon. For example, in `php:8.4-fpm-alpine`, we can easily get node `v22`, but not `v24`.
Even when referencing non-default repos, `v24` is not available in `edge` or any other repo AFAICT, [link](https://pkgs.alpinelinux.org/packages?name=nodejs&branch=edge&repo=&arch=&origin=&flagged=&maintainer=).

As a first possible solution, there are [unofficial builds](https://unofficial-builds.nodejs.org/download/release/) which work on alpine with its `musl` libc variant. However, these are available for `x86_64` only. Tooling like `n` or `nvm` relies on those builds as well, so is of no help here.

Looking at the contents of an exemplary pre-built binary package:
<details>
<summary>Release contents</summary>

```
node-v22.9.0-linux-x64-musl
├── bin
│   ├── corepack -> ../lib/node_modules/corepack/dist/corepack.js
│   ├── node
│   ├── npm -> ../lib/node_modules/npm/bin/npm-cli.js
│   └── npx -> ../lib/node_modules/npm/bin/npx-cli.js
├── CHANGELOG.md
├── include
│   └── node
├── lib
│   └── node_modules
├── LICENSE
├── README.md
└── share
    ├── doc
    └── man

9 directories, 7 files
```

</details>

...the same binaries/library files are present in the official nodejs-alpine container image, which is also available in all required processor architectures.

Compiling node is another alternative I'm currently looking into, but considering the [process required](https://github.com/nodejs/docker-node/blob/main/Dockerfile-alpine.template), I believe a few `COPY` instructions might be easier to maintain.

That said, I'd be happy to hear more ideas on this.

TODO:
- [x] Shrink down the number of combinations (we likely don't need the newest node version for images with PHP < v8.3)
- [x] Decide on node build/install process (-> we'll compile)
- [ ] Implement changes for frankenphp image as well